### PR TITLE
patch: removed bad import

### DIFF
--- a/lambdas/producer/src/hml_reader/__init__.py
+++ b/lambdas/producer/src/hml_reader/__init__.py
@@ -1,6 +1,5 @@
 from hml_reader.client import async_get, get
 from hml_reader.schemas.weather import HML
-from hml_reader.publish import fetch_data
 from hml_reader.settings import Settings
 
-__all__ = ["async_get", "get", "fetch_data", "HML", "Settings"]
+__all__ = ["async_get", "get", "HML", "Settings"]


### PR DESCRIPTION
### Added:
- removed outdated import of `from hml_reader.publish import fetch_data` from the `src/hml_reader/__init__.py` file as this file no longer exists
- `fetch_data.py` was converted into the lambda