### PR TITLE
AWS Rabbit MQ: wired up security group for the web console

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,9 +49,10 @@ module "iam_roles" {
 module "security_groups" {
   source = "./modules/security_groups"
 
-  app_name    = var.app_name
-  environment = var.environment
-  vpc_id      = data.aws_vpc.existing.id
+  app_name              = var.app_name
+  environment           = var.environment
+  vpc_id                = data.aws_vpc.existing.id
+  rabbitmq_console_cidr = var.rabbitmq_console_cidr
 }
 
 module "data_stores" {

--- a/terraform/modules/messaging/outputs.tf
+++ b/terraform/modules/messaging/outputs.tf
@@ -17,3 +17,8 @@ output "rabbitmq_secret_arn" {
   description = "The ARN of the Secrets Manager secret for RabbitMQ credentials."
   value       = aws_secretsmanager_secret.rabbitmq.arn
 }
+
+output "rabbitmq_web_console_url" {
+  description = "The web console URL for the RabbitMQ broker."
+  value       = aws_mq_broker.rabbitmq.instances[0].console_url
+}

--- a/terraform/modules/security_groups/main.tf
+++ b/terraform/modules/security_groups/main.tf
@@ -73,6 +73,14 @@ resource "aws_security_group" "rabbitmq" {
     security_groups = [aws_security_group.lambda.id, aws_security_group.fargate.id]
   }
 
+  # Allow inbound HTTPS traffic to RabbitMQ management console from specified CIDR
+  ingress { 
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.rabbitmq_console_cidr]
+  }
+
   tags = {
     Name        = "${var.app_name}-${var.environment}-rabbitmq-sg"
     Environment = var.environment

--- a/terraform/modules/security_groups/variables.tf
+++ b/terraform/modules/security_groups/variables.tf
@@ -13,3 +13,7 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "rabbitmq_console_cidr" {
+  description = "The CIDR block allowed to access the RabbitMQ web management console."
+  type        = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -16,3 +16,8 @@ output "rabbitmq_broker_id" {
   description = "The ID of the Amazon MQ for RabbitMQ broker."
   value       = module.messaging.rabbitmq_broker_id
 }
+
+output "rabbitmq_web_console_url" {
+  description = "The Amazon RabbitMQ web console URL."
+  value       = module.messaging.rabbitmq_web_console_url
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -8,8 +8,9 @@ environment         = "test"
 team_name           = "EDFS"
 
 # --- Existing Network Details ---
-vpc_name            = "Test-Main"
-subnet_name_pattern = "Test-App*"
+vpc_name                = "Test-Main"
+subnet_name_pattern     = "Test-App*"
+rabbitmq_console_cidr   = "10.0.0.0/8"
 
 # --- Application Image and Code ---
 # This would typically be passed in from a CI/CD pipeline

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,6 +32,11 @@ variable "subnet_name_pattern" {
   type        = string
 }
 
+variable "rabbitmq_console_cidr" {
+  description = "The CIDR block allowed to access the RabbitMQ web management console."
+  type        = string
+}
+
 # --- Application Configuration ---
 variable "docker_image_uri" {
   description = "The full URI of the public Docker image on ghcr.io (e.g., 'ghcr.io/user/repo:tag')."


### PR DESCRIPTION
Added an input param for an allowed CIDR range and made the web console accessible on port 443 from that CIDR range. Also added the web console URL to the terraform outputs.