### PR TITLE
patch: added debug flag to support verbose logs

### DIFF
--- a/ecs/worker/Dockerfile
+++ b/ecs/worker/Dockerfile
@@ -32,4 +32,4 @@ RUN ./compiler.sh no-e --uv
 WORKDIR "/t-route/src/troute-rnr"
 RUN uv pip install -e '.[iac]'
 
-CMD ["bash", "-c", "uv run python main.py --iac"]
+CMD ["bash", "-c", "uv run python main.py --iac --debug"]


### PR DESCRIPTION
### Added:
- in latest `PI-7-NGWPC-6258` commit there was the addition of the `--debug` flag. this will support that logging level flag in the docker command